### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -20,7 +20,7 @@ jobs:
 
             - uses: actions/checkout@master
             - name: Publish to Registry
-              uses: elgohr/Publish-Docker-Github-Action@master
+              uses: elgohr/Publish-Docker-Github-Action@v5
               with:
                   name: mlf-core/sc_autoencoder
                   username: mlf-core


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore